### PR TITLE
递归处理 include 文件并在输出目录生成替换后的全量 XML

### DIFF
--- a/Ra3.BattleNet.Metadata.Tests/MetadataTests.cs
+++ b/Ra3.BattleNet.Metadata.Tests/MetadataTests.cs
@@ -157,6 +157,63 @@ namespace Ra3.BattleNet.Metadata.Tests
             path.Should().Contain("Application");
         }
 
+
+        [Fact]
+        public void ReplaceVariablesInFile_RecursivelyProcessesIncludeFiles()
+        {
+            // Arrange
+            var tempDir = Path.Combine(Path.GetTempPath(), $"metadata-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var rootPath = Path.Combine(tempDir, "metadata.xml");
+                var includePath = Path.Combine(tempDir, "included.xml");
+
+                File.WriteAllText(rootPath, """
+<?xml version="1.0" encoding="UTF-8"?>
+<Metadata>
+  <Defines>
+    <Commit>${ENV:TEST_COMMIT}</Commit>
+  </Defines>
+  <Include Source="included.xml" Type="public" />
+</Metadata>
+""");
+
+                File.WriteAllText(includePath, """
+<?xml version="1.0" encoding="UTF-8"?>
+<Metadata>
+  <Defines>
+    <Value>${ENV:TEST_COMMIT}</Value>
+  </Defines>
+</Metadata>
+""");
+
+                Environment.SetEnvironmentVariable("TEST_COMMIT", "abc123", EnvironmentVariableTarget.Process);
+                var metadata = Metadata.LoadFromFile(rootPath);
+
+                // Act
+                metadata.ReplaceVariablesInFile(rootPath);
+
+                // Assert
+                var rootResult = File.ReadAllText(rootPath);
+                var includeResult = File.ReadAllText(includePath);
+
+                rootResult.Should().Contain("abc123");
+                rootResult.Should().NotContain("${ENV:TEST_COMMIT}");
+
+                includeResult.Should().Contain("abc123");
+                includeResult.Should().NotContain("${ENV:TEST_COMMIT}");
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, recursive: true);
+                }
+            }
+        }
+
         [Fact]
         public void GetIncludeTree_ReturnsTreeStructure()
         {

--- a/Ra3.BattleNet.Metadata/Metadata.cs
+++ b/Ra3.BattleNet.Metadata/Metadata.cs
@@ -119,7 +119,7 @@ namespace Ra3.BattleNet.Metadata
 
                 // 处理Includes和变量替换
                 ProcessIncludes(root);
-                ReplaceVariables(root);
+                ReplaceVariables(root, _currentFilePath);
 
                 return doc;
             }
@@ -143,23 +143,58 @@ namespace Ra3.BattleNet.Metadata
         {
             try
             {
-                // 加载原始XML文件
-                var doc = XDocument.Load(filePath);
-                var root = doc.Root ?? throw new InvalidOperationException("无效的XML结构: 缺少根节点");
-
-                // 验证所有Include/Module资源
-                ValidateResources(root, Path.GetDirectoryName(filePath));
-
-                // 替换变量
-                ReplaceVariables(root);
-
-                // 保存回原文件
-                doc.Save(filePath);
+                var fullPath = Path.GetFullPath(filePath);
+                ReplaceVariablesInFileRecursive(
+                    fullPath,
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase));
             }
             catch (Exception ex)
             {
                 throw new InvalidOperationException($"替换变量失败: {filePath}", ex);
             }
+        }
+
+        private void ReplaceVariablesInFileRecursive(string filePath, HashSet<string> processingPaths, HashSet<string> processedPaths)
+        {
+            if (processedPaths.Contains(filePath))
+            {
+                return;
+            }
+
+            if (!processingPaths.Add(filePath))
+            {
+                throw new InvalidOperationException($"检测到循环引用: {filePath}");
+            }
+
+            var doc = XDocument.Load(filePath);
+            var root = doc.Root ?? throw new InvalidOperationException("无效的XML结构: 缺少根节点");
+            var basePath = Path.GetDirectoryName(filePath)
+                ?? throw new InvalidOperationException($"无法确定文件目录: {filePath}");
+
+            // 验证并递归处理所有Include/Module资源
+            ValidateResources(root, basePath);
+
+            foreach (var include in root.Descendants().Where(e => e.Name.LocalName == "Include" || e.Name.LocalName == "Module"))
+            {
+                var path = include.Attribute("Path")?.Value ?? include.Attribute("Source")?.Value;
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    continue;
+                }
+
+                var referencedFile = Path.GetFullPath(Path.Combine(basePath, path.Replace('/', '\\')));
+                if (File.Exists(referencedFile))
+                {
+                    ReplaceVariablesInFileRecursive(referencedFile, processingPaths, processedPaths);
+                }
+            }
+
+            ReplaceVariables(root, filePath);
+            doc.Save(filePath);
+
+            processingPaths.Remove(filePath);
+            processedPaths.Add(filePath);
         }
 
         private void ValidateResources(XElement element, string basePath)
@@ -344,7 +379,7 @@ namespace Ra3.BattleNet.Metadata
         /// 递归替换XML元素中的变量
         /// </summary>
         /// <param name="element">要处理的XML元素</param>
-        private void ReplaceVariables(XElement element)
+        private void ReplaceVariables(XElement element, string currentFilePath)
         {
             try
             {
@@ -352,7 +387,7 @@ namespace Ra3.BattleNet.Metadata
                 {
                     try
                     {
-                        attr.Value = ResolveVariables(attr.Value, element);
+                        attr.Value = ResolveVariables(attr.Value, element, currentFilePath);
                     }
                     catch (Exception ex)
                     {
@@ -364,7 +399,7 @@ namespace Ra3.BattleNet.Metadata
                 {
                     try
                     {
-                        element.Value = ResolveVariables(element.Value, element);
+                        element.Value = ResolveVariables(element.Value, element, currentFilePath);
                     }
                     catch (Exception ex)
                     {
@@ -374,7 +409,7 @@ namespace Ra3.BattleNet.Metadata
 
                 foreach (var child in element.Elements())
                 {
-                    ReplaceVariables(child);
+                    ReplaceVariables(child, currentFilePath);
                 }
             }
             catch (Exception ex)
@@ -383,7 +418,7 @@ namespace Ra3.BattleNet.Metadata
             }
         }
 
-        private string ResolveVariables(string input, XElement context)
+        private string ResolveVariables(string input, XElement context, string currentFilePath)
         {
             return System.Text.RegularExpressions.Regex.Replace(input, @"\$\{(.*?)\}", match =>
             {
@@ -401,12 +436,12 @@ namespace Ra3.BattleNet.Metadata
                         var fileToHash = parts.Length > 1 ? parts[1] : "";
                         if (string.IsNullOrEmpty(fileToHash))
                         {
-                            return ComputeFileHash(_currentFilePath);
+                            return ComputeFileHash(currentFilePath);
                         }
-                        var dir = Path.GetDirectoryName(_currentFilePath);
+                        var dir = Path.GetDirectoryName(currentFilePath);
                         if (string.IsNullOrEmpty(dir))
                         {
-                            return $"HASH_ERROR_DIR_NOT_FOUND:{_currentFilePath}";
+                            return $"HASH_ERROR_DIR_NOT_FOUND:{currentFilePath}";
                         }
                         return ComputeFileHash(Path.Combine(dir, fileToHash));
                     case "META":


### PR DESCRIPTION
### Motivation
- 使变量替换不仅限于主 XML 文件，而是递归地处理 `Include`/`Module` 引用的子文件，最终在输出目录生成经过替换的完整 XML 文件。
- 避免在递归引用场景中出现路径上下文错位和重复或循环处理导致的问题。

### Description
- 将 `ReplaceVariablesInFile` 重构为 `ReplaceVariablesInFileRecursive`，从入口文件开始递归处理所有 `Include`/`Module` 并在处理后保存每个文件。
- 引入 `processingPaths` 和 `processedPaths` 两个集合用于防止重复处理并在检测到循环引用时抛出异常。
- 将 `ReplaceVariables` 和 `ResolveVariables` 签名改为显式接收 `currentFilePath`，使 `${MD5:...}` 等基于文件路径的变量在递归处理中按所属文件解析。
- 在 `Compile()`/生成流程中同步传入 `_currentFilePath` 以保持变量解析上下文的正确性。
- 新增临时文件写回保存逻辑：每个被处理文件在变量替换后会 `doc.Save(filePath)` 写回原文件。

### Testing
- 新增单元测试 `ReplaceVariablesInFile_RecursivelyProcessesIncludeFiles`（位于 `Ra3.BattleNet.Metadata.Tests/MetadataTests.cs`），在临时目录创建 `metadata.xml` 与 `included.xml`，并断言对两个文件的 `${ENV:TEST_COMMIT}` 都被替换。
- 在当前环境尝试运行 `dotnet test Metadata.sln` 但环境中缺失 `dotnet`，测试未能执行（失败：`command not found`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995470054f4832b98d5355d6c0d3cbc)