### PR TITLE
docs: add XML comments for Metadata query APIs and document models

### DIFF
--- a/Ra3.BattleNet.Metadata.Tests/MetadataTests.cs
+++ b/Ra3.BattleNet.Metadata.Tests/MetadataTests.cs
@@ -228,5 +228,71 @@ namespace Ra3.BattleNet.Metadata.Tests
             tree.Should().NotBeNullOrEmpty();
             tree.Should().Contain("Metadata");
         }
+
+        [Fact]
+        public void ToNodeTree_ShouldKeepLeafValue()
+        {
+            // Arrange
+            var filePath = Path.Combine(_testDataPath, "valid-metadata.xml");
+            var metadata = Metadata.LoadFromFile(filePath);
+
+            // Act
+            var root = metadata.ToNodeTree();
+            var app = root.Children.Single(c => c.Name == "Application");
+            var appName = app.Children.Single(c => c.Name == "Name");
+
+            // Assert
+            appName.Value.Should().Be("Test Application");
+        }
+
+        [Fact]
+        public void GetBusinessEntities_ShouldReturnTypedEntities()
+        {
+            // Arrange
+            var filePath = Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "Metadata", "metadata.xml");
+            var metadata = Metadata.LoadFromFile(filePath);
+
+            // Act
+            var entities = metadata.GetBusinessEntities();
+
+            // Assert
+            entities.Should().Contain(e => e.EntityType == "Application" && e.Id == "RA3BattleNet");
+            entities.Should().Contain(e => e.EntityType == "Mod" && e.Id == "Corona");
+            entities.Should().Contain(e => e.EntityType == "Markdown");
+            entities.Should().Contain(e => e.EntityType == "Manifest");
+        }
+
+
+        [Fact]
+        public void Mods_ShouldExposeVersionAndPackages()
+        {
+            // Arrange
+            var filePath = Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "Metadata", "metadata.xml");
+            var metadata = Metadata.LoadFromFile(filePath);
+
+            // Act
+            var corona = metadata.Mods().Single(m => m.Id == "Corona");
+
+            // Assert
+            corona.Version.Should().Be("3.229");
+            corona.Packages.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void Catalog_ShouldProvideConvenientLookup()
+        {
+            // Arrange
+            var filePath = Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "Metadata", "metadata.xml");
+            var metadata = Metadata.LoadFromFile(filePath);
+
+            // Act
+            var catalog = metadata.Catalog();
+            var app = catalog.Application("RA3BattleNet");
+
+            // Assert
+            app.Should().NotBeNull();
+            app!.Version.Should().Be("1.5.2.0");
+        }
+
     }
 }

--- a/Ra3.BattleNet.Metadata/Metadata.cs
+++ b/Ra3.BattleNet.Metadata/Metadata.cs
@@ -14,6 +14,7 @@ namespace Ra3.BattleNet.Metadata
         private readonly Dictionary<string, string> _envVars = new();
         private readonly Dictionary<string, string> _fileHashes = new();
         private string _currentFilePath = string.Empty;
+        private string? _value = null;
         private Metadata? _parent = null;
         private string _includeType = "public"; // "public" 或 "private"
 
@@ -24,6 +25,10 @@ namespace Ra3.BattleNet.Metadata
         public IReadOnlyList<Metadata> DefineChildren => _defineChildren;
         public Metadata? Parent => _parent;
         public string IncludeType => _includeType;
+        /// <summary>
+        /// 节点文本值（仅叶子节点有效）。
+        /// </summary>
+        public string? Value => _value;
 
         public Metadata()
         {
@@ -224,6 +229,12 @@ namespace Ra3.BattleNet.Metadata
             {
                 element.SetAttributeValue(var.Key, var.Value);
             }
+
+            if (!string.IsNullOrWhiteSpace(_value) && !_children.Any())
+            {
+                element.Value = _value;
+            }
+
             foreach (var child in _children)
             {
                 element.Add(child.ToXElement());
@@ -298,6 +309,97 @@ namespace Ra3.BattleNet.Metadata
                     _children.Add(childMetadata);
                 }
             }
+
+            if (!element.HasElements)
+            {
+                _value = element.Value;
+            }
+        }
+
+        /// <summary>
+        /// 将当前元数据转换为可反序列化使用的树状结构。
+        /// </summary>
+        public MetadataNode ToNodeTree()
+        {
+            return BuildNode(this);
+        }
+
+        /// <summary>
+        /// 获取所有业务实体（Application/Mod/Markdown/Image/Manifest）节点。
+        /// </summary>
+        public IReadOnlyList<BusinessEntity> GetBusinessEntities()
+        {
+            var supported = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "Application", "Mod", "Markdown", "Image", "Manifest"
+            };
+
+            var allNodes = GetAllNodes();
+            var entities = new List<BusinessEntity>();
+
+            foreach (var node in allNodes.Where(n => supported.Contains(n.Name)))
+            {
+                var entity = new BusinessEntity
+                {
+                    EntityType = node.Name,
+                    Id = node.Get("ID"),
+                    Path = node.GetElementPath(),
+                    Attributes = new Dictionary<string, string>(node._variables, StringComparer.OrdinalIgnoreCase),
+                    Properties = CollectEntityProperties(node)
+                };
+
+                entities.Add(entity);
+            }
+
+            return entities;
+        }
+
+        private static Dictionary<string, string> CollectEntityProperties(Metadata node)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var child in node._children)
+            {
+                if (!string.IsNullOrWhiteSpace(child._value) && !result.ContainsKey(child.Name))
+                {
+                    result[child.Name] = child._value;
+                }
+            }
+
+            var packageCount = node._children.FirstOrDefault(c => c.Name == "Packages")
+                ?._children.Count(c => c.Name == "Package");
+            if (packageCount.HasValue)
+            {
+                result["PackageCount"] = packageCount.Value.ToString();
+            }
+
+            var fileCount = node._children.Count(c => c.Name == "File");
+            if (fileCount > 0)
+            {
+                result["FileCount"] = fileCount.ToString();
+            }
+
+            return result;
+        }
+
+        private MetadataNode BuildNode(Metadata metadata)
+        {
+            return new MetadataNode(
+                metadata.Name,
+                metadata.Value,
+                new Dictionary<string, string>(metadata._variables, StringComparer.OrdinalIgnoreCase),
+                metadata._children.Select(BuildNode).ToList());
+        }
+
+        private List<Metadata> GetAllNodes()
+        {
+            var nodes = new List<Metadata> { this };
+            foreach (var child in _children)
+            {
+                nodes.AddRange(child.GetAllNodes());
+            }
+
+            return nodes;
         }
 
         /// <summary>

--- a/Ra3.BattleNet.Metadata/MetadataModels.cs
+++ b/Ra3.BattleNet.Metadata/MetadataModels.cs
@@ -1,0 +1,45 @@
+namespace Ra3.BattleNet.Metadata;
+
+/// <summary>
+/// 通用元数据树节点（适合反序列化后继续加工）。
+/// </summary>
+/// <param name="Name">节点名（即 XML 标签名）。</param>
+/// <param name="Value">叶子节点文本值；若包含子节点则通常为 <c>null</c> 或空字符串。</param>
+/// <param name="Attributes">节点属性字典（如 <c>ID</c>、<c>Source</c>）。</param>
+/// <param name="Children">子节点集合。</param>
+public sealed record MetadataNode(
+    string Name,
+    string? Value,
+    IReadOnlyDictionary<string, string> Attributes,
+    IReadOnlyList<MetadataNode> Children);
+
+/// <summary>
+/// 业务实体快照，便于直接查询核心字段。
+/// </summary>
+public sealed class BusinessEntity
+{
+    /// <summary>
+    /// 实体类型（如 <c>Application</c>、<c>Mod</c>、<c>Markdown</c>）。
+    /// </summary>
+    public string EntityType { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 实体 ID（来自节点 <c>ID</c> 属性）。
+    /// </summary>
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// 实体在元数据树中的路径（<c>A -&gt; B -&gt; C</c>）。
+    /// </summary>
+    public string Path { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 原始属性字典。
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Attributes { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// 归一化后的常用属性（如 <c>PackageCount</c>、<c>FileCount</c>）。
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Properties { get; init; } = new Dictionary<string, string>();
+}

--- a/Ra3.BattleNet.Metadata/MetadataQueryExtensions.cs
+++ b/Ra3.BattleNet.Metadata/MetadataQueryExtensions.cs
@@ -1,0 +1,119 @@
+namespace Ra3.BattleNet.Metadata;
+
+/// <summary>
+/// <see cref="Metadata"/> 的业务查询扩展方法。
+/// </summary>
+public static class MetadataQueryExtensions
+{
+    /// <summary>
+    /// 构建目录式查询入口。
+    /// </summary>
+    /// <param name="root">元数据根对象。</param>
+    /// <returns>可按实体类型查询的目录对象。</returns>
+    public static MetadataCatalog Catalog(this Metadata root)
+    {
+        return new MetadataCatalog(root);
+    }
+
+    /// <summary>
+    /// 获取所有 Mod 实体。
+    /// </summary>
+    /// <param name="root">元数据根对象。</param>
+    /// <returns>Mod 实体列表。</returns>
+    public static IReadOnlyList<ModEntry> Mods(this Metadata root)
+    {
+        return root.GetAllElements("Mod")
+            .Select(ToMod)
+            .ToList();
+    }
+
+    /// <summary>
+    /// 获取所有 Application 实体。
+    /// </summary>
+    /// <param name="root">元数据根对象。</param>
+    /// <returns>Application 实体列表。</returns>
+    public static IReadOnlyList<ApplicationEntry> Applications(this Metadata root)
+    {
+        return root.GetAllElements("Application")
+            .Select(ToApplication)
+            .ToList();
+    }
+
+    /// <summary>
+    /// 获取所有 Markdown 资源。
+    /// </summary>
+    /// <param name="root">元数据根对象。</param>
+    /// <returns>Markdown 资源列表。</returns>
+    public static IReadOnlyList<MarkdownEntry> Markdowns(this Metadata root)
+    {
+        return root.GetAllElements("Markdown")
+            .Select(node => new MarkdownEntry(
+                Id: node.Get("ID") ?? string.Empty,
+                Source: node.Get("Source"),
+                Hash: node.Get("Hash"),
+                Raw: node))
+            .ToList();
+    }
+
+    /// <summary>
+    /// 获取所有图片资源。
+    /// </summary>
+    /// <param name="root">元数据根对象。</param>
+    /// <returns>图片资源列表。</returns>
+    public static IReadOnlyList<ImageEntry> Images(this Metadata root)
+    {
+        return root.GetAllElements("Image")
+            .Select(node => new ImageEntry(
+                Id: node.Get("ID") ?? string.Empty,
+                Source: node.Get("Source"),
+                Url: node.Get("Url"),
+                Raw: node))
+            .ToList();
+    }
+
+    /// <summary>
+    /// 将 <c>Mod</c> 节点映射为 <see cref="ModEntry"/>。
+    /// </summary>
+    private static ModEntry ToMod(Metadata node)
+    {
+        return new ModEntry(
+            Id: node.Get("ID") ?? string.Empty,
+            Version: node.Find("CurrentVersion")?.Value,
+            Icon: node.Find("Icon")?.Value,
+            Packages: ReadPackages(node),
+            Raw: node);
+    }
+
+    /// <summary>
+    /// 将 <c>Application</c> 节点映射为 <see cref="ApplicationEntry"/>。
+    /// </summary>
+    private static ApplicationEntry ToApplication(Metadata node)
+    {
+        return new ApplicationEntry(
+            Id: node.Get("ID") ?? string.Empty,
+            Version: node.Find("Version")?.Value,
+            Packages: ReadPackages(node),
+            Raw: node);
+    }
+
+    /// <summary>
+    /// 读取一个业务实体下的全部版本包。
+    /// </summary>
+    private static IReadOnlyList<PackageEntry> ReadPackages(Metadata node)
+    {
+        var packagesNode = node.Find("Packages");
+        if (packagesNode == null)
+        {
+            return [];
+        }
+
+        return packagesNode.Children
+            .Where(c => c.Name == "Package")
+            .Select(package => new PackageEntry(
+                Version: package.Get("Version") ?? string.Empty,
+                ReleaseDate: package.Find("ReleaseDate")?.Value,
+                ManifestId: package.Find("Manifest")?.Value,
+                Raw: package))
+            .ToList();
+    }
+}

--- a/Ra3.BattleNet.Metadata/MetadataQueryModels.cs
+++ b/Ra3.BattleNet.Metadata/MetadataQueryModels.cs
@@ -1,0 +1,94 @@
+namespace Ra3.BattleNet.Metadata;
+
+/// <summary>
+/// 面向业务使用的查询入口（类似“创意工坊”浏览视图）。
+/// </summary>
+public sealed class MetadataCatalog
+{
+    private readonly Metadata _root;
+
+    /// <summary>
+    /// 基于已加载的元数据根节点构造查询目录。
+    /// </summary>
+    /// <param name="root">元数据根对象。</param>
+    public MetadataCatalog(Metadata root)
+    {
+        _root = root;
+    }
+
+    /// <summary>
+    /// 获取全部 Mod 实体。
+    /// </summary>
+    public IReadOnlyList<ModEntry> Mods => _root.Mods();
+
+    /// <summary>
+    /// 获取全部 Application 实体。
+    /// </summary>
+    public IReadOnlyList<ApplicationEntry> Applications => _root.Applications();
+
+    /// <summary>
+    /// 获取全部 Markdown 资源。
+    /// </summary>
+    public IReadOnlyList<MarkdownEntry> Markdowns => _root.Markdowns();
+
+    /// <summary>
+    /// 获取全部图片资源。
+    /// </summary>
+    public IReadOnlyList<ImageEntry> Images => _root.Images();
+
+    /// <summary>
+    /// 按 ID 查找 Mod。
+    /// </summary>
+    public ModEntry? Mod(string id) => Mods.FirstOrDefault(m => string.Equals(m.Id, id, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// 按 ID 查找 Application。
+    /// </summary>
+    public ApplicationEntry? Application(string id) => Applications.FirstOrDefault(a => string.Equals(a.Id, id, StringComparison.OrdinalIgnoreCase));
+}
+
+/// <summary>
+/// Application 业务实体。
+/// </summary>
+/// <param name="Id">应用 ID。</param>
+/// <param name="Version">应用当前版本（来自 <c>&lt;Version&gt;</c>）。</param>
+/// <param name="Packages">版本包列表。</param>
+/// <param name="Raw">原始元数据节点。</param>
+public sealed record ApplicationEntry(string Id, string? Version, IReadOnlyList<PackageEntry> Packages, Metadata Raw);
+
+/// <summary>
+/// Mod 业务实体。
+/// </summary>
+/// <param name="Id">Mod ID。</param>
+/// <param name="Version">当前版本（来自 <c>&lt;CurrentVersion&gt;</c>）。</param>
+/// <param name="Icon">图标资源 ID。</param>
+/// <param name="Packages">版本包列表。</param>
+/// <param name="Raw">原始元数据节点。</param>
+public sealed record ModEntry(string Id, string? Version, string? Icon, IReadOnlyList<PackageEntry> Packages, Metadata Raw);
+
+/// <summary>
+/// 版本包实体。
+/// </summary>
+/// <param name="Version">包版本号（来自 <c>Package@Version</c>）。</param>
+/// <param name="ReleaseDate">发布日期。</param>
+/// <param name="ManifestId">Manifest 资源 ID。</param>
+/// <param name="Raw">原始元数据节点。</param>
+public sealed record PackageEntry(string Version, string? ReleaseDate, string? ManifestId, Metadata Raw);
+
+/// <summary>
+/// Markdown 资源实体。
+/// </summary>
+/// <param name="Id">资源 ID。</param>
+/// <param name="Source">源文件路径。</param>
+/// <param name="Hash">内容哈希值。</param>
+/// <param name="Raw">原始元数据节点。</param>
+public sealed record MarkdownEntry(string Id, string? Source, string? Hash, Metadata Raw);
+
+/// <summary>
+/// 图片资源实体。
+/// </summary>
+/// <param name="Id">资源 ID。</param>
+/// <param name="Source">本地源文件路径。</param>
+/// <param name="Url">远程图片 URL。</param>
+/// <param name="Raw">原始元数据节点。</param>
+public sealed record ImageEntry(string Id, string? Source, string? Url, Metadata Raw);

--- a/Ra3.BattleNet.Metadata/Program.cs
+++ b/Ra3.BattleNet.Metadata/Program.cs
@@ -77,6 +77,21 @@ namespace Ra3.BattleNet.Metadata
                 Console.WriteLine("=== Include 引用树 ===");
                 Console.WriteLine(verifiedMetadata.GetIncludeTree());
 
+                Console.WriteLine("=== 业务实体概览 ===");
+                var entities = verifiedMetadata.GetBusinessEntities();
+                foreach (var entity in entities)
+                {
+                    var id = string.IsNullOrWhiteSpace(entity.Id) ? "<no-id>" : entity.Id;
+                    Console.WriteLine($"- [{entity.EntityType}] {id} @ {entity.Path}");
+                }
+
+                Console.WriteLine();
+                Console.WriteLine("=== 查询API示例（metadata.Mods()） ===");
+                foreach (var mod in verifiedMetadata.Mods())
+                {
+                    Console.WriteLine($"Mod={mod.Id}, Version={mod.Version}, Packages={mod.Packages.Count}");
+                }
+
                 Console.WriteLine("处理完成！");
             }
             catch (InvalidOperationException ex) when (ex.Message.Contains("循环引用"))

--- a/USAGE_EXAMPLE.md
+++ b/USAGE_EXAMPLE.md
@@ -20,6 +20,27 @@ var metadata = Metadata.LoadFromFile("./Metadata/metadata.xml");
 
 ## 常见使用场景
 
+
+### 场景0：像你说的那样直接用 `metadata.Mods()` / `mod.Version`
+
+```csharp
+var metadata = Metadata.LoadFromFile("./Metadata/metadata.xml");
+
+// 方式A：直接扩展方法
+foreach (var mod in metadata.Mods())
+{
+    Console.WriteLine($"{mod.Id} -> {mod.Version}");
+}
+
+var corona = metadata.Mods().FirstOrDefault(m => m.Id == "Corona");
+Console.WriteLine(corona?.Version); // 3.229
+
+// 方式B：Catalog 入口（更像“数据仓库”）
+var catalog = metadata.Catalog();
+var app = catalog.Application("RA3BattleNet");
+Console.WriteLine(app?.Version); // 1.5.2.0
+```
+
 ### 场景1：访问 Corona 模组的 Changelog
 
 ```csharp


### PR DESCRIPTION
### Motivation
- 提升新引入的查询友好型 API 的可读性和 IDE 悬停提示，便于调用方直接使用 `metadata.Mods()` / `metadata.Catalog()` 等表达式而不用反复阅读实现细节。 
- 明确 `Metadata` 中叶子节点文本值语义，避免调用方误用并为序列化/反序列化场景提供可用的树形结构和业务实体快照。 

### Description
- 为查询模型新增并补充了 XML 注释：添加 `Ra3.BattleNet.Metadata/MetadataModels.cs`（`MetadataNode`、`BusinessEntity`）以说明字段与语义。 
- 添加并注释查询类型与记录：`Ra3.BattleNet.Metadata/MetadataQueryModels.cs`（`MetadataCatalog`、`ModEntry`、`ApplicationEntry`、`PackageEntry`、`MarkdownEntry`、`ImageEntry`）。 
- 添加并注释扩展方法：`Ra3.BattleNet.Metadata/MetadataQueryExtensions.cs`，提供 `Catalog()`、`Mods()`、`Applications()`、`Markdowns()`、`Images()` 等便捷 API 及映射辅助方法（`ToMod`/`ToApplication`/`ReadPackages`）。 
- 在 `Ra3.BattleNet.Metadata/Metadata.cs` 中保存并导出叶子节点值（新增 `_value` 字段与 `Value` 属性），并增加 `ToNodeTree()`、`GetBusinessEntities()`、`CollectEntityProperties()`、`BuildNode()`、`GetAllNodes()` 等辅助方法以导出树形 `MetadataNode` 与归一化的 `BusinessEntity` 列表。 
- 在 `Program.cs` 增加示例输出，打印业务实体概览以及 `metadata.Mods()` 示例；在 `USAGE_EXAMPLE.md` 新增“场景0”示例；并在测试项目 `Ra3.BattleNet.Metadata.Tests/MetadataTests.cs` 中新增覆盖 `ToNodeTree`、`GetBusinessEntities`、`Mods`、`Catalog` 的单元测试。 

### Testing
- 已向测试项目添加相关单元测试（`ToNodeTree_ShouldKeepLeafValue`、`GetBusinessEntities_ShouldReturnTypedEntities`、`Mods_ShouldExposeVersionAndPackages`、`Catalog_ShouldProvideConvenientLookup`），但尝试运行 `dotnet test` 失败，因执行环境缺少 `dotnet` CLI（`bash: command not found: dotnet`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69971bee7ae4832bb2f9ef84318969be)